### PR TITLE
Support custom domains

### DIFF
--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -31,6 +31,7 @@ provider:
   environment:
     APPLICATION_TABLE:
       Ref: ApplicationDynamoDBTable
+    API_REGION: "${self:provider.region}"  
 
   # optional
   websocketApiName: websocket-chat-${self:provider.stage}

--- a/example/src/websocket-client.js
+++ b/example/src/websocket-client.js
@@ -26,6 +26,11 @@ class Client {
         }
 
         if(!this.client){
+            
+            if(config.requestContext.apiId){
+                config.requestContext.domainName  = `${config.requestContext.apiId}.execute-api.${process.env.API_REGION}.amazonaws.com`
+            }
+          
             this.client = new AWS.ApiGatewayManagementApi({
                 apiVersion: "2018-11-29",
                 endpoint: `https://${config.requestContext.domainName}/${config.requestContext.stage}`


### PR DESCRIPTION
# Description
this PR changes how the @connections endpoint for the apigateway management api is constructed.
it appears that the endpoint does not support custom domain names and one needs to use the AWS URL, if a custom domain is setup it will cause the endpoint to be set to this URL and hence break. see https://github.com/serverless/serverless-websockets-plugin/issues/6 for more details.

# Solution
requestContext also contains a parameter ```apiId``` which combined with the region can be used to properly construct the endpoint URL. I did not find a better way to make the region available other than an env variable, there might be better ways to do it.  this change ensures that sending messages always turns to the correct @connections endpoint regardless of the domain used for the api. 


closes https://github.com/serverless/serverless-websockets-plugin/issues/6